### PR TITLE
Change hostname to nodename

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Many users of this role wish to also use Ansible to then _build_ Docker images a
     - geerlingguy.docker
 ```
 
-For configure swarm you should add variable `docker_swarm_configure: true` for all nodes, and `docker_swarm_manager: true` for managers. `inventory_hostname` must be equal to hostname (`ansible_hostname`) for correct remove nodes.
+For configure swarm you should add variable `docker_swarm_configure: true` for all nodes, and `docker_swarm_manager: true` for managers. `inventory_hostname` must be equal to hostname (`ansible_nodename`) for correct remove nodes.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,7 +73,7 @@ docker_log_max_file: "3"
 docker_storage_driver: overlay2
 docker_data_root: "/var/lib/docker"
 
-docker_cert_dir: "/etc/ssl_certs/{{ ansible_hostname }}"
+docker_cert_dir: "/etc/ssl_certs/{{ ansible_nodename }}"
 docker_log_address: "tcp+tls://192.168.1.11:6514"
 docker_ca_cert: "{{ docker_cert_dir }}/ca.d/cacert.pem"
 docker_cert: "{{ docker_cert_dir }}/cert.d/{{ ansible_default_ipv4.address }}.pem"
@@ -101,6 +101,10 @@ docker_daemon_syslog:
     syslog-tls-cert: "{{ docker_cert }}"
     syslog-tls-key: "{{ docker_key }}"
     tag: "{{ docker_log_tag }}"
+
+disable_networks:
+  - test
+  - dev
 
 docker_additional_networks: []
 #   - name: prometheus_network

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,10 +102,6 @@ docker_daemon_syslog:
     syslog-tls-key: "{{ docker_key }}"
     tag: "{{ docker_log_tag }}"
 
-disable_networks:
-  - test
-  - dev
-
 docker_additional_networks: []
 #   - name: prometheus_network
 #    bridge_name: prom_bridge  # this one has to be less than 15 symbols

--- a/tasks/docker-swarm.yml
+++ b/tasks/docker-swarm.yml
@@ -111,14 +111,14 @@
 
 - name: Promote nodes
   community.docker.docker_node:
-    hostname: "{{ ansible_hostname }}"
+    hostname: "{{ ansible_nodename }}"
     role: manager
   delegate_to: "{{ swarm_manager_hostname }}"
   when: docker_swarm_manager
 
 - name: Demote nodes
   community.docker.docker_node:
-    hostname: "{{ ansible_hostname }}"
+    hostname: "{{ ansible_nodename }}"
     role: worker
   delegate_to: "{{ swarm_manager_hostname }}"
   when: not docker_swarm_manager
@@ -145,13 +145,13 @@
 
 - name: Set availability to nodes
   community.docker.docker_node:
-    hostname: "{{ ansible_hostname }}"
+    hostname: "{{ ansible_nodename }}"
     availability: "{{ docker_swarm_availability }}"
   delegate_to: "{{ swarm_manager_hostname }}"
 
 - name: Replace node labels with new ones
   community.docker.docker_node:
-    hostname: "{{ ansible_hostname }}"
+    hostname: "{{ ansible_nodename }}"
     labels: "{{ docker_swarm_node_labels }}"
     labels_state: replace
   delegate_to: "{{ swarm_manager_hostname }}"


### PR DESCRIPTION
In case hostname include domain part (if you host named as host.domain.tld instead just host), ansible_hostname will return only first part before dot. But docker swarm will join node by fullname host.domain.tld and after that node removing will always fail. Fix that behaviour using ansible_nodename instead of ansible_hostname.